### PR TITLE
Exclude drools-eclipse module in soaProfile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,6 @@
 
   <modules>
     <module>drools-ant</module>
-    <module>drools-eclipse</module>
   </modules>
 
   <profiles>
@@ -57,6 +56,17 @@
       </activation>
       <modules>
         <module>droolsjbpm-tools-distribution</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>notSoaProfile</id>
+      <activation>
+        <property>
+          <name>!soa</name>
+        </property>
+      </activation>
+      <modules>
+        <module>drools-eclipse</module>
       </modules>
     </profile>
   </profiles>


### PR DESCRIPTION
BRMS build don't need drools-eclipse module and  would have build problem in MEAD
