### PR TITLE
Add support for Kepler

### DIFF
--- a/drools-eclipse/org.drools.eclipse/src/main/java/org/drools/eclipse/util/DroolsRuntimeManager.java
+++ b/drools-eclipse/org.drools.eclipse/src/main/java/org/drools/eclipse/util/DroolsRuntimeManager.java
@@ -123,6 +123,14 @@ public class DroolsRuntimeManager {
         File pluginRoot = new Path(pluginRootString).toFile();
         files = pluginRoot.listFiles();
         boolean found = false;
+        // search for eclipse jdt 3.9.x jar
+        for (int i = 0; i < files.length; i++) {
+            if (files[i].getAbsolutePath().indexOf("org.eclipse.jdt.core_3.9") > -1) {
+                jars.add(files[i].getAbsolutePath());
+                found = true;
+                break;
+            }
+        }
         // search for eclipse jdt 3.8.x jar
         for (int i = 0; i < files.length; i++) {
             if (files[i].getAbsolutePath().indexOf("org.eclipse.jdt.core_3.8") > -1) {


### PR DESCRIPTION
Eclipse Kepler (ad JBDS 7) is packaged with jdt core 3.9.x. Thiss adds support for copying the jar.
See https://bugzilla.redhat.com/show_bug.cgi?id=1001928
