### PR TITLE
Using of non-empty constructor of DefaultHandler

### DIFF
--- a/drools-eclipse/org.jbpm.eclipse/src/main/java/org/jbpm/eclipse/action/ImportWorkItemsDialog.java
+++ b/drools-eclipse/org.jbpm.eclipse/src/main/java/org/jbpm/eclipse/action/ImportWorkItemsDialog.java
@@ -339,7 +339,8 @@ public class ImportWorkItemsDialog extends Dialog {
 		        	String content = "[";
 		        	for (WorkDefinitionImpl def: workDefs.values()) {
 			        	if (def.getDefaultHandler() != null) {
-			        		content += EOL + "  \"" + def.getName() + "\" : new " + def.getDefaultHandler() + "(),";
+			        		content += EOL + "  \"" + def.getName() + "\" : new "
+			        			+ def.getDefaultHandler().replaceFirst("[^()]+$", "$0()") + ",";
 			        	}
 			        }
 		        	if (content.endsWith(",")) {
@@ -354,7 +355,8 @@ public class ImportWorkItemsDialog extends Dialog {
 			        }
 			        for (WorkDefinitionImpl def: workDefs.values()) {
 			        	if (def.getDefaultHandler() != null) {
-			        		newContent += EOL + "  \"" + def.getName() + "\" : new " + def.getDefaultHandler() + "(),";
+			        		newContent += EOL + "  \"" + def.getName() + "\" : new "
+			        			   + def.getDefaultHandler().replaceFirst("[^()]+$", "$0()") + ",";
 			        	}
 			        }
 			        newContent += content;


### PR DESCRIPTION
According to the jBPM documentation a DefaultHander can have non-empty constructor (e.g. with argument ksession). It is sometimes necessary for work item handler to be able to access to the Process's variables, etc.
