### PR TITLE
Tycho plugin version now comes from parent pom

### DIFF
--- a/drools-eclipse/org.drools.updatesite/pom.xml
+++ b/drools-eclipse/org.drools.updatesite/pom.xml
@@ -32,31 +32,9 @@
   </properties>
   <build>
     <plugins>
-      <!-- Suppress calling source-plugin for an update site build because it will cause clean to fire and delete the target/ folder AFTER producing the update site ~nickboldt -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>never</goal>
-            </goals>
-            <phase>never</phase>
-          </execution>
-          <execution>
-            <id>attach-test-sources</id>
-            <phase>never</phase>
-            <goals>
-              <goal>never</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.jboss.tools.tycho-plugins</groupId>
         <artifactId>repository-utils</artifactId>
-        <version>${version.org.eclipse.tycho}</version>
         <executions>
           <execution>
             <id>generate-facade</id>


### PR DESCRIPTION
 * maven-source-plugin override was removed,
   because it no longer applies. Original issue was
   caused by the "jar" goal, instead of "jar-no-fork"
   which is used now. The "jar" goal would fork the
   execution and thus call the clean phase again.

Needs to be merged together with https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/117