### PR TITLE
[DROOLS-1216] disable enforcer execution 'ban-blacklisted-dependencie…

### DIFF
--- a/drools-eclipse/pom.xml
+++ b/drools-eclipse/pom.xml
@@ -62,6 +62,11 @@
             <id>ban-uberjars</id>
             <phase>none</phase>
           </execution>
+          <!-- Does not work properly together with the tycho-plugin -->
+          <execution>
+            <id>ban-blacklisted-dependencies</id>
+            <phase>none</phase>
+          </execution>
         </executions>
       </plugin>
       <plugin>


### PR DESCRIPTION
…s' as it does not work with tycho plugins