### PR TITLE
Bug fixes for 6.5.x

### DIFF
--- a/drools-eclipse/org.guvnor.tools/META-INF/MANIFEST.MF
+++ b/drools-eclipse/org.guvnor.tools/META-INF/MANIFEST.MF
@@ -12,10 +12,16 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.compare,
  org.guvnor.eclipse.webdav
-Export-Package: org.guvnor.tools,org.guvnor.tools.actions,org.guvnor.t
- ools.perspectives,org.guvnor.tools.preferences,org.guvnor.tools.prope
- rties,org.guvnor.tools.utils,org.guvnor.tools.utils.webdav,org.guvnor
- .tools.views,org.guvnor.tools.views.model,org.guvnor.tools.wizards
+Export-Package: org.guvnor.tools,
+ org.guvnor.tools.actions,
+ org.guvnor.tools.perspectives,
+ org.guvnor.tools.preferences,
+ org.guvnor.tools.properties,
+ org.guvnor.tools.utils,
+ org.guvnor.tools.utils.webdav,
+ org.guvnor.tools.views,
+ org.guvnor.tools.views.model,
+ org.guvnor.tools.wizards
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .

--- a/drools-eclipse/org.kie.eclipse/src/main/java/org/kie/eclipse/utils/FileUtils.java
+++ b/drools-eclipse/org.kie.eclipse/src/main/java/org/kie/eclipse/utils/FileUtils.java
@@ -249,13 +249,16 @@ public class FileUtils {
 	public static void addBPMN2Builder(IJavaProject project, IProgressMonitor monitor) throws CoreException {
 	    IProjectDescription description = project.getProject().getDescription();
 	    ICommand[] commands = description.getBuildSpec();
-	    ICommand[] newCommands = new ICommand[commands.length + 1];
+	    ICommand[] newCommands = new ICommand[commands.length + 2];
 	    System.arraycopy(commands, 0, newCommands, 0, commands.length);
 	
-	    ICommand javaCommand = description.newCommand();
-	    javaCommand.setBuilderName("org.eclipse.bpmn2.modeler.core.bpmn2Builder");
-	    javaCommand.setBuilderName("org.eclipse.wst.validation.validationbuilder");
-	    newCommands[commands.length] = javaCommand;
+	    ICommand bpmn2BuilderCommand = description.newCommand();
+	    bpmn2BuilderCommand.setBuilderName("org.eclipse.bpmn2.modeler.core.bpmn2Builder");
+	    newCommands[commands.length] = bpmn2BuilderCommand;
+	    
+	    ICommand wstValidationCommand = description.newCommand();
+	    wstValidationCommand.setBuilderName("org.eclipse.wst.validation.validationbuilder");
+	    newCommands[commands.length+1] = wstValidationCommand;
 	    
 	    description.setBuildSpec(newCommands);
 	    project.getProject().setDescription(description, monitor);

--- a/drools-eclipse/org.kie.eclipse/src/main/java/org/kie/eclipse/wizard/project/AbstractKieProjectWizard.java
+++ b/drools-eclipse/org.kie.eclipse/src/main/java/org/kie/eclipse/wizard/project/AbstractKieProjectWizard.java
@@ -230,8 +230,7 @@ public abstract class AbstractKieProjectWizard extends BasicNewResourceWizard {
     	if (shouldAddMavenBuilder) {
     		FileUtils.addMavenBuilder(project, monitor);
     	}
-    	else
-    		startPage.getRuntimeManager().addBuilder(project, monitor);
+   		startPage.getRuntimeManager().addBuilder(project, monitor);
     }
     
     protected void setClasspath(IJavaProject project, IProgressMonitor monitor)

--- a/drools-eclipse/pom.xml
+++ b/drools-eclipse/pom.xml
@@ -118,7 +118,7 @@
           <artifact>
             <groupId>org.jboss.tools.integration-stack</groupId>
             <artifactId>target-platform</artifactId>
-            <version>4.3.1.Final</version>
+            <version>4.4.0.CR1-SNAPSHOT</version>
             <type>target</type>
             <classifier>base</classifier>
           </artifact>

--- a/drools-eclipse/pom.xml
+++ b/drools-eclipse/pom.xml
@@ -118,7 +118,7 @@
           <artifact>
             <groupId>org.jboss.tools.integration-stack</groupId>
             <artifactId>target-platform</artifactId>
-            <version>4.4.0.CR1-SNAPSHOT</version>
+            <version>4.4.0.CR1</version>
             <type>target</type>
             <classifier>base</classifier>
           </artifact>


### PR DESCRIPTION
Add Drools and BPMN2 model validation builder to new projects

    This is related to https://issues.jboss.org/browse/DROOLS-1250
    the DRL *false* compile errors did not appear in newly created maven
    projects because the Drools builder was not added to the .project file

Fix Export-Package list in guvnor-tools MANIFEST
