### PR TITLE
DROOLS-5456

### DIFF
--- a/drools-eclipse/org.drools.eclipse.feature/feature.xml
+++ b/drools-eclipse/org.drools.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.drools.eclipse.feature"
       label="%featurename"
-      version="7.49.0.qualifier"
+      version="7.58.0.qualifier"
       provider-name="%providername"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0">
@@ -56,7 +56,7 @@
          id="org.drools.eclipse"
          download-size="0"
          install-size="0"
-         version="7.49.0.qualifier"
+         version="7.58.0.qualifier"
          unpack="false"/>
 
 </feature>

--- a/drools-eclipse/org.drools.eclipse.feature/pom.xml
+++ b/drools-eclipse/org.drools.eclipse.feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-eclipse</artifactId>
-    <version>7.49.0-SNAPSHOT</version>
+    <version>7.58.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/drools-eclipse/org.drools.eclipse.test/META-INF/MANIFEST.MF
+++ b/drools-eclipse/org.drools.eclipse.test/META-INF/MANIFEST.MF
@@ -2,10 +2,10 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Drools Eclipse Test Plugin
 Bundle-SymbolicName: org.drools.eclipse.test
-Bundle-Version: 7.49.0.qualifier
+Bundle-Version: 7.58.0.qualifier
 Bundle-Vendor: JBoss, a division of Red Hat
 Fragment-Host: org.drools.eclipse
 Bundle-Localization: plugin
 Require-Bundle: org.junit;bundle-version="[4.8.1,5.0.0)"
 Bundle-ClassPath: .
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/drools-eclipse/org.drools.eclipse.test/pom.xml
+++ b/drools-eclipse/org.drools.eclipse.test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-eclipse</artifactId>
-    <version>7.49.0-SNAPSHOT</version>
+    <version>7.58.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/drools-eclipse/org.drools.eclipse/META-INF/MANIFEST.MF
+++ b/drools-eclipse/org.drools.eclipse/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Drools Eclipse Plug-in
 Bundle-SymbolicName: org.drools.eclipse;singleton:=true
-Bundle-Version: 7.49.0.qualifier
+Bundle-Version: 7.58.0.qualifier
 Bundle-Activator: org.drools.eclipse.DroolsEclipsePlugin
 Bundle-Vendor: JBoss by Red Hat
 Bundle-Localization: plugin
@@ -69,7 +69,7 @@ Bundle-ClassPath: .,
  lib/slf4j-api.jar,
  lib/protobuf-java.jar,
  lib/commons-math3.jar
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.drools.compiler.compiler,
  org.drools.compiler.lang.descr,
  org.drools.eclipse,

--- a/drools-eclipse/org.drools.eclipse/pom.xml
+++ b/drools-eclipse/org.drools.eclipse/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-eclipse</artifactId>
-    <version>7.49.0-SNAPSHOT</version>
+    <version>7.58.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.drools.eclipse</artifactId>

--- a/drools-eclipse/org.drools.updatesite/category.xml
+++ b/drools-eclipse/org.drools.updatesite/category.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="org.drools.eclipse.feature_7.49.0.qualifier" id="org.drools.eclipse.feature" version="7.49.0.qualifier">
+   <feature url="org.drools.eclipse.feature_7.58.0.qualifier" id="org.drools.eclipse.feature" version="7.58.0.qualifier">
       <category name="droolsjbpm"/>
    </feature>
-   <feature url="org.drools.eclipse.feature.source_7.49.0.qualifier" id="org.drools.eclipse.feature.source" version="7.49.0.qualifier">
+   <feature url="org.drools.eclipse.feature.source_7.58.0.qualifier" id="org.drools.eclipse.feature.source" version="7.58.0.qualifier">
       <category name="droolsjbpm"/>
    </feature>
-   <feature url="org.guvnor.tools.feature_7.49.0.qualifier" id="org.guvnor.tools.feature" version="7.49.0.qualifier">
+   <feature url="org.guvnor.tools.feature_7.58.0.qualifier" id="org.guvnor.tools.feature" version="7.58.0.qualifier">
       <category name="droolsjbpm"/>
    </feature>
-   <feature url="org.guvnor.tools.feature.source_7.49.0.qualifier" id="org.guvnor.tools.feature.source" version="7.49.0.qualifier">
+   <feature url="org.guvnor.tools.feature.source_7.58.0.qualifier" id="org.guvnor.tools.feature.source" version="7.58.0.qualifier">
       <category name="droolsjbpm"/>
    </feature>
-   <feature url="org.jbpm.eclipse.feature_7.49.0.qualifier" id="org.jbpm.eclipse.feature" version="7.49.0.qualifier">
+   <feature url="org.jbpm.eclipse.feature_7.58.0.qualifier" id="org.jbpm.eclipse.feature" version="7.58.0.qualifier">
       <category name="droolsjbpm"/>
    </feature>
-   <feature url="org.jbpm.eclipse.feature.source_7.49.0.qualifier" id="org.jbpm.eclipse.feature.source" version="7.49.0.qualifier">
+   <feature url="org.jbpm.eclipse.feature.source_7.58.0.qualifier" id="org.jbpm.eclipse.feature.source" version="7.58.0.qualifier">
       <category name="droolsjbpm"/>
    </feature>
-   <feature url="org.jboss.tools.runtime.drools.detector.feature_7.49.0.qualifier.jar" id="org.jboss.tools.runtime.drools.detector.feature" version="7.49.0.qualifier">
+   <feature url="org.jboss.tools.runtime.drools.detector.feature_7.58.0.qualifier.jar" id="org.jboss.tools.runtime.drools.detector.feature" version="7.58.0.qualifier">
       <category name="droolsjbpm"/>
    </feature>
-   <feature url="org.jboss.tools.runtime.drools.detector.feature.source_7.49.0.qualifier" id="org.jboss.tools.runtime.drools.detector.feature.source" version="7.49.0.qualifier">
+   <feature url="org.jboss.tools.runtime.drools.detector.feature.source_7.58.0.qualifier" id="org.jboss.tools.runtime.drools.detector.feature.source" version="7.58.0.qualifier">
       <category name="droolsjbpm"/>
    </feature>
-   <feature url="features/org.kie.eclipse.feature_7.49.0.qualifier.jar" id="org.kie.eclipse.feature" version="7.49.0.qualifier">
+   <feature url="features/org.kie.eclipse.feature_7.58.0.qualifier.jar" id="org.kie.eclipse.feature" version="7.58.0.qualifier">
       <category name="droolsjbpm"/>
    </feature>
-   <feature url="org.kie.eclipse.feature.source_7.49.0.qualifier" id="org.kie.eclipse.feature.source" version="7.49.0.qualifier">
+   <feature url="org.kie.eclipse.feature.source_7.58.0.qualifier" id="org.kie.eclipse.feature.source" version="7.58.0.qualifier">
       <category name="droolsjbpm"/>
    </feature>
-   <feature url="org.kie.eclipse.navigator.feature_7.49.0.qualifier.jar" id="org.kie.eclipse.navigator.feature" version="7.49.0.qualifier">
+   <feature url="org.kie.eclipse.navigator.feature_7.58.0.qualifier.jar" id="org.kie.eclipse.navigator.feature" version="7.58.0.qualifier">
       <category name="droolsjbpm"/>
    </feature>
-   <feature url="org.kie.eclipse.navigator.feature.source_7.49.0.qualifier" id="org.kie.eclipse.navigator.feature.source" version="7.49.0.qualifier">
+   <feature url="org.kie.eclipse.navigator.feature.source_7.58.0.qualifier" id="org.kie.eclipse.navigator.feature.source" version="7.58.0.qualifier">
       <category name="droolsjbpm"/>
    </feature>
    <category-def name="droolsjbpm" label="Drools and jBPM">

--- a/drools-eclipse/org.drools.updatesite/pom.xml
+++ b/drools-eclipse/org.drools.updatesite/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-eclipse</artifactId>
-    <version>7.49.0-SNAPSHOT</version>
+    <version>7.58.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.drools.updatesite</artifactId>

--- a/drools-eclipse/org.guvnor.eclipse.webdav/META-INF/MANIFEST.MF
+++ b/drools-eclipse/org.guvnor.eclipse.webdav/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.guvnor.eclipse.webdav
-Bundle-Version: 7.49.0.qualifier
+Bundle-Version: 7.58.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.webdav,org.eclipse.webdav.client,org.eclip
@@ -10,7 +10,7 @@ Export-Package: org.eclipse.webdav,org.eclipse.webdav.client,org.eclip
  nal.authentication;x-internal:=true,org.eclipse.webdav.internal.kerne
  l;x-internal:=true,org.eclipse.webdav.internal.kernel.utils;x-interna
  l:=true,org.eclipse.webdav.internal.utils;x-internal:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: javax.xml.parsers,
  javax.xml.transform,
  org.w3c.dom,

--- a/drools-eclipse/org.guvnor.eclipse.webdav/pom.xml
+++ b/drools-eclipse/org.guvnor.eclipse.webdav/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-eclipse</artifactId>
-    <version>7.49.0-SNAPSHOT</version>
+    <version>7.58.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/drools-eclipse/org.guvnor.tools.feature/feature.xml
+++ b/drools-eclipse/org.guvnor.tools.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.guvnor.tools.feature"
       label="%featurename"
-      version="7.49.0.qualifier"
+      version="7.58.0.qualifier"
       provider-name="%providername"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0">
@@ -32,14 +32,14 @@
          id="org.guvnor.eclipse.webdav"
          download-size="0"
          install-size="0"
-         version="7.49.0.qualifier"
+         version="7.58.0.qualifier"
          unpack="false"/>
 
    <plugin
          id="org.guvnor.tools"
          download-size="0"
          install-size="0"
-         version="7.49.0.qualifier"
+         version="7.58.0.qualifier"
          unpack="false"/>
 
 </feature>

--- a/drools-eclipse/org.guvnor.tools.feature/pom.xml
+++ b/drools-eclipse/org.guvnor.tools.feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-eclipse</artifactId>
-    <version>7.49.0-SNAPSHOT</version>
+    <version>7.58.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/drools-eclipse/org.guvnor.tools.test/META-INF/MANIFEST.MF
+++ b/drools-eclipse/org.guvnor.tools.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Drools Guvnor Eclipse Test Plugin
 Bundle-SymbolicName: org.guvnor.tools.test
-Bundle-Version: 7.49.0.qualifier
+Bundle-Version: 7.58.0.qualifier
 Bundle-Vendor: JBoss, a division of Red Hat
 Fragment-Host: org.guvnor.tools
 Bundle-Localization: plugin
@@ -13,4 +13,4 @@ Require-Bundle: org.junit;bundle-version="[4.8.1,5.0.0)",
  org.eclipse.jdt.launching;bundle-version="3.5.0",
  org.eclipse.jst.j2ee;bundle-version="1.1.300"
 Bundle-ClassPath: .
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/drools-eclipse/org.guvnor.tools.test/pom.xml
+++ b/drools-eclipse/org.guvnor.tools.test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-eclipse</artifactId>
-    <version>7.49.0-SNAPSHOT</version>
+    <version>7.58.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/drools-eclipse/org.guvnor.tools/META-INF/MANIFEST.MF
+++ b/drools-eclipse/org.guvnor.tools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.name
 Bundle-SymbolicName: org.guvnor.tools;singleton:=true
-Bundle-Version: 7.49.0.qualifier
+Bundle-Version: 7.58.0.qualifier
 Bundle-Activator: org.guvnor.tools.Activator
 Bundle-Vendor: %plugin.provider
 Bundle-Localization: plugin
@@ -22,6 +22,6 @@ Export-Package: org.guvnor.tools,
  org.guvnor.tools.views,
  org.guvnor.tools.views.model,
  org.guvnor.tools.wizards
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .

--- a/drools-eclipse/org.guvnor.tools/pom.xml
+++ b/drools-eclipse/org.guvnor.tools/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-eclipse</artifactId>
-    <version>7.49.0-SNAPSHOT</version>
+    <version>7.58.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/drools-eclipse/org.jboss.tools.runtime.drools.detector.feature/feature.xml
+++ b/drools-eclipse/org.jboss.tools.runtime.drools.detector.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.runtime.drools.detector.feature"
       label="%featureName"
-      version="7.49.0.qualifier"
+      version="7.58.0.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.runtime.drools.detector"
       license-feature="org.jboss.tools.foundation.license.feature"

--- a/drools-eclipse/org.jboss.tools.runtime.drools.detector.feature/pom.xml
+++ b/drools-eclipse/org.jboss.tools.runtime.drools.detector.feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-eclipse</artifactId>
-    <version>7.49.0-SNAPSHOT</version>
+    <version>7.58.0-SNAPSHOT</version>
   </parent>
   <groupId>org.jboss.tools.runtime.features</groupId>
   <artifactId>org.jboss.tools.runtime.drools.detector.feature</artifactId>

--- a/drools-eclipse/org.jboss.tools.runtime.drools.detector/META-INF/MANIFEST.MF
+++ b/drools-eclipse/org.jboss.tools.runtime.drools.detector/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %BundleName
 Bundle-SymbolicName: org.jboss.tools.runtime.drools.detector;singleton:=true
-Bundle-Version: 7.49.0.qualifier
+Bundle-Version: 7.58.0.qualifier
 Bundle-Activator: org.jboss.tools.runtime.drools.detector.RuntimeDroolsActivator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.ui,
  org.drools.eclipse
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: %BundleVendor
 Bundle-Localization: plugin
 Import-Package: org.kie.eclipse.preferences,

--- a/drools-eclipse/org.jboss.tools.runtime.drools.detector/pom.xml
+++ b/drools-eclipse/org.jboss.tools.runtime.drools.detector/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 	    <groupId>org.drools</groupId>
 	    <artifactId>drools-eclipse</artifactId>
-	    <version>7.49.0-SNAPSHOT</version>
+	    <version>7.58.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.runtime.plugins</groupId>
 	<artifactId>org.jboss.tools.runtime.drools.detector</artifactId>

--- a/drools-eclipse/org.jbpm.eclipse.feature/feature.xml
+++ b/drools-eclipse/org.jbpm.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jbpm.eclipse.feature"
       label="%featurename"
-      version="7.49.0.qualifier"
+      version="7.58.0.qualifier"
       provider-name="%providername"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0">
@@ -34,7 +34,7 @@
          id="org.jbpm.eclipse"
          download-size="0"
          install-size="0"
-         version="7.49.0.qualifier"
+         version="7.58.0.qualifier"
          unpack="false"/>
 
 </feature>

--- a/drools-eclipse/org.jbpm.eclipse.feature/pom.xml
+++ b/drools-eclipse/org.jbpm.eclipse.feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-eclipse</artifactId>
-    <version>7.49.0-SNAPSHOT</version>
+    <version>7.58.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/drools-eclipse/org.jbpm.eclipse/META-INF/MANIFEST.MF
+++ b/drools-eclipse/org.jbpm.eclipse/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: jBPM Eclipse Plug-in
 Bundle-SymbolicName: org.jbpm.eclipse;singleton:=true
-Bundle-Version: 7.49.0.qualifier
+Bundle-Version: 7.58.0.qualifier
 Bundle-Activator: org.jbpm.eclipse.JBPMEclipsePlugin
 Bundle-Vendor: JBoss by Red Hat
 Bundle-Localization: plugin
@@ -29,7 +29,7 @@ Bundle-ClassPath: .,
  lib/antlr-runtime.jar,
  lib/xstream.jar,
  lib/slf4j-api.jar
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.jbpm.eclipse
 Import-Package: org.drools.eclipse.builder,
  org.drools.eclipse.util

--- a/drools-eclipse/org.jbpm.eclipse/pom.xml
+++ b/drools-eclipse/org.jbpm.eclipse/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-eclipse</artifactId>
-    <version>7.49.0-SNAPSHOT</version>
+    <version>7.58.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/drools-eclipse/org.kie.eclipse.feature/feature.xml
+++ b/drools-eclipse/org.kie.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.kie.eclipse.feature"
       label="%featurename"
-      version="7.49.0.qualifier"
+      version="7.58.0.qualifier"
       provider-name="%providername"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0">
@@ -59,7 +59,7 @@
          id="org.kie.eclipse"
          download-size="0"
          install-size="0"
-         version="7.49.0.qualifier"
+         version="7.58.0.qualifier"
          unpack="false"/>
 
 </feature>

--- a/drools-eclipse/org.kie.eclipse.feature/pom.xml
+++ b/drools-eclipse/org.kie.eclipse.feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-eclipse</artifactId>
-    <version>7.49.0-SNAPSHOT</version>
+    <version>7.58.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/drools-eclipse/org.kie.eclipse.navigator.feature/feature.xml
+++ b/drools-eclipse/org.kie.eclipse.navigator.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.kie.eclipse.navigator.feature"
       label="%featurename"
-      version="7.49.0.qualifier"
+      version="7.58.0.qualifier"
       provider-name="JBoss by Red Hat"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0">
@@ -44,7 +44,7 @@
          id="org.kie.eclipse.navigator"
          download-size="0"
          install-size="0"
-         version="7.49.0.qualifier"
+         version="7.58.0.qualifier"
          unpack="false"/>
 
 </feature>

--- a/drools-eclipse/org.kie.eclipse.navigator.feature/pom.xml
+++ b/drools-eclipse/org.kie.eclipse.navigator.feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-eclipse</artifactId>
-    <version>7.49.0-SNAPSHOT</version>
+    <version>7.58.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/drools-eclipse/org.kie.eclipse.navigator/META-INF/MANIFEST.MF
+++ b/drools-eclipse/org.kie.eclipse.navigator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Kie Navigator
 Bundle-SymbolicName: org.kie.eclipse.navigator;singleton:=true
-Bundle-Version: 7.49.0.qualifier
+Bundle-Version: 7.58.0.qualifier
 Bundle-Activator: org.kie.eclipse.navigator.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.forms,
@@ -17,7 +17,7 @@ Require-Bundle: org.eclipse.ui,
  org.kie.eclipse,
  org.eclipse.ui.workbench,
  org.eclipse.ui.ide
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Import-Package: com.jcraft.jsch,
  org.drools.eclipse.util,

--- a/drools-eclipse/org.kie.eclipse.navigator/pom.xml
+++ b/drools-eclipse/org.kie.eclipse.navigator/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-eclipse</artifactId>
-    <version>7.49.0-SNAPSHOT</version>
+    <version>7.58.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/drools-eclipse/org.kie.eclipse/META-INF/MANIFEST.MF
+++ b/drools-eclipse/org.kie.eclipse/META-INF/MANIFEST.MF
@@ -2,11 +2,11 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Common plugin for Drools/jBPM
 Bundle-SymbolicName: org.kie.eclipse;singleton:=true
-Bundle-Version: 7.49.0.qualifier
+Bundle-Version: 7.58.0.qualifier
 Bundle-Activator: org.kie.eclipse.Activator
 Bundle-Vendor: JBoss by Red Hat
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,

--- a/drools-eclipse/org.kie.eclipse/pom.xml
+++ b/drools-eclipse/org.kie.eclipse/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-eclipse</artifactId>
-    <version>7.49.0-SNAPSHOT</version>
+    <version>7.58.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/drools-eclipse/pom.xml
+++ b/drools-eclipse/pom.xml
@@ -6,21 +6,21 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-tools</artifactId>
-    <version>7.49.0-SNAPSHOT</version>
+    <version>7.58.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-eclipse</artifactId>
   <packaging>pom</packaging>
-  
+
   <name>Drools, jBPM and Guvnor plugins for Eclipse</name>
   <description>
     To use these Eclipse plugins in production, use the download site linked on:
     http://www.jboss.org/drools/downloads
-    
+
     To use these Eclipse plugins locally during development,
     see the pom description of the module org.drools.updatesite.
   </description>
-  
+
   <properties>
     <!-- disabling javadoc as it seems to interfere with source generation:
          http://dev.eclipse.org/mhonarc/lists/tycho-user/msg04453.html -->
@@ -38,7 +38,7 @@
     <module>org.guvnor.eclipse.webdav</module>
     <module>org.guvnor.tools</module>
     <module>org.guvnor.tools.feature</module>
-    <module>org.guvnor.tools.test</module> 
+    <module>org.guvnor.tools.test</module>
     <module>org.jbpm.eclipse</module>
     <module>org.jbpm.eclipse.feature</module>
     <module>org.kie.eclipse</module>
@@ -194,5 +194,5 @@
       </plugin>
     </plugins>
   </build>
-<version>7.49.0-SNAPSHOT</version>
+<version>7.58.0-SNAPSHOT</version>
 </project>

--- a/droolsjbpm-tools-distribution/pom.xml
+++ b/droolsjbpm-tools-distribution/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-tools</artifactId>
-    <version>7.49.0-SNAPSHOT</version>
+    <version>7.58.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>droolsjbpm-tools-distribution</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-parent</artifactId>
-    <version>7.49.0-SNAPSHOT</version>
+    <version>7.58.0-SNAPSHOT</version>
     <!-- relativePath causes out-of-date problems on hudson slaves -->
     <!--<relativePath>../droolsjbpm-build-bootstrap/pom.xml</relativePath>-->
   </parent>
@@ -24,7 +24,7 @@
     <!-- Set a default value for BUILD_NUMBER (provided by Jenkins) for local builds. -->
     <!-- This is generally wrong, but it at least enables the default 'mvn clean install' build. -->
     <BUILD_NUMBER>1</BUILD_NUMBER>
-    <!-- There are duplicated classes between the standard and 'p2.eclipse-plugin:*' dependencies. There is no easy way to fix this other than introduce complex configs. 
+    <!-- There are duplicated classes between the standard and 'p2.eclipse-plugin:*' dependencies. There is no easy way to fix this other than introduce complex configs.
         This is leaking from drools-eclipse submodule because of Maven 3.6.3 switch? -->
     <enforcer.failOnDuplicatedClasses>false</enforcer.failOnDuplicatedClasses>
   </properties>


### PR DESCRIPTION
Updating to JDK 8 minimum
Updating requirements to JDK 8 Minimum.
Updating to version 7.58.0-SNAPSHOT for upstream import of JDK 8 build.
